### PR TITLE
fix/modify types for clangd

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ This is beta software. Please let me know by creating an issue if you run into a
 
 ## Contributing
 
-Please keep PRs small and open Issues first for anything substantial. AI slop OK as long as it is tested, passes checks, and doesn't smell too bad.
+Please keep PRs small and open Issues first for anything substantial. AI slop O.K. as long as it is tested, passes checks, and doesn't smell too bad.
 
 ### Setup
 

--- a/cmd/generate/README.md
+++ b/cmd/generate/README.md
@@ -7,14 +7,34 @@ Types have been modified to always be union types. A method generator has also b
 ## Use
 
 From the root of the repo, run
+
 ```bash
 go run ./cmd/generate_protocol
 ```
+
 This will generate LSP message types in `internal/protocol`
 
 ## Key Differences from gopls
 
 The main difference from the gopls implementation is in the handling of union types. While gopls simplifies some union types to single types for backward compatibility and easy operability with gopls, this implementation preserves the full union types as specified in the LSP spec.
+
+### Custom Field Additions
+
+The generator supports adding custom fields to generated types through the `additionalFields` map in `tables.go`. This allows extending LSP types with non-standard fields needed for specific language servers.
+
+e.g.
+
+```go
+// additionalFields defines extra fields to add to specific types during generation
+// The key is the Go struct name (after applying goName), the value is a slice of field definitions
+var additionalFields = map[string][]string{
+    "BaseSymbolInformation": {
+        "Score float64 `json:\"score,omitempty\"` // Added for clangd compatibility",
+    },
+}
+```
+
+This adds a `Score` field to the `BaseSymbolInformation` type, necessary for `clangd`.
 
 ## Attribution
 
@@ -38,7 +58,7 @@ exact version can be tied to a githash. By default, the command will download th
 
 The specification has five sections
 
-1. Requests, which describe the Request and Response types for request methods (e.g., *textDocument/didChange*),
+1. Requests, which describe the Request and Response types for request methods (e.g., _textDocument/didChange_),
 2. Notifications, which describe the Request types for notification methods,
 3. Structures, which describe named struct-like types,
 4. TypeAliases, which describe type aliases,

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -67,7 +67,7 @@ func propStar(name string, t NameType, gotype string) (string, string) {
 		star = "" // passed by reference, so no need for *
 	} else {
 		switch gotype {
-		case "bool", "uint32", "int32", "string", "interface{}":
+		case "bool", "uint32", "int32", "string", "interface{}", "any":
 			star = "" // gopls compatibility if t.Optional
 		}
 	}

--- a/cmd/generate/methods.go
+++ b/cmd/generate/methods.go
@@ -62,7 +62,7 @@ func generateMethodForRequest(out *bytes.Buffer, r *Request) {
 	}
 	if notNil(r.Result) {
 		resultType = goplsName(r.Result)
-		if resultType == "interface{}" || resultType == "string" {
+		if resultType == "interface{}" || resultType == "string" || resultType == "any" {
 		} else if strings.HasPrefix(resultType, "*") {
 			resultType = "*protocol." + resultType[1:]
 		} else if strings.HasPrefix(resultType, "[]") {

--- a/cmd/generate/output.go
+++ b/cmd/generate/output.go
@@ -237,13 +237,21 @@ func genStructs(model *Model) {
 		for _, ex := range s.Mixins {
 			fmt.Fprintf(out, "\t%s\n", goName(ex.Name))
 		}
+
+		// Add any additional fields defined in additionalFields map
+		if additionalFields, ok := additionalFields[nm]; ok {
+			for _, field := range additionalFields {
+				fmt.Fprintf(out, "\t%s\n", field)
+			}
+		}
+
 		out.WriteString("}\n")
 		types[nm] = out.String()
 	}
 
 	// base types
 	// (For URI and DocumentUri, see ../uri.go.)
-	types["LSPAny"] = "type LSPAny = interface{}\n"
+	types["LSPAny"] = "type LSPAny = any\n"
 	// A special case, the only previously existing Or type
 	types["DocumentDiagnosticReport"] = "type DocumentDiagnosticReport = Or_DocumentDiagnosticReport // (alias) \n"
 
@@ -320,7 +328,7 @@ func genGenTypes() {
 			sort.Strings(names)
 			fmt.Fprintf(out, "// created for Or %v\n", names)
 			fmt.Fprintf(out, "type %s struct {%s\n", nm, linex(nt.line+1))
-			fmt.Fprintf(out, "\tValue interface{} `json:\"value\"`\n")
+			fmt.Fprintf(out, "\tValue any `json:\"value\"`\n")
 
 		case "and":
 			fmt.Fprintf(out, "// created for And\n")

--- a/cmd/generate/tables.go
+++ b/cmd/generate/tables.go
@@ -116,13 +116,21 @@ var disambiguate = map[string]adjust{
 // which entries of disambiguate got used
 var usedDisambiguate = make(map[string]bool)
 
+// additionalFields defines extra fields to add to specific types during generation
+// The key is the Go struct name (after applying goName), the value is a slice of field definitions
+var additionalFields = map[string][]string{
+	"BaseSymbolInformation": {
+		"Score float64 `json:\"score,omitempty\"` // added for clangd compatibility",
+	},
+}
+
 // For spec compliance, we keep only essential type mappings that don't override OR types
 var goplsType = map[string]string{
 	"ConfigurationParams": "ParamConfiguration",
 	// "DocumentUri":         "DocumentUri",
 	"InitializeParams": "ParamInitialize",
-	"LSPAny":           "interface{}",
-	"[]LSPAny":         "[]interface{}",
+	"LSPAny":           "any",
+	"[]LSPAny":         "[]any",
 	"[]uinteger":       "[]uint32",
 	"boolean":          "bool",
 	"decimal":          "float64",

--- a/integrationtests/snapshots/typescript/hover/outside-file.snap
+++ b/integrationtests/snapshots/typescript/hover/outside-file.snap
@@ -1,0 +1,1 @@
+No hover information available for this position on the following line:

--- a/internal/protocol/tsprotocol.go
+++ b/internal/protocol/tsprotocol.go
@@ -80,7 +80,8 @@ type BaseSymbolInformation struct {
 	// user interface purposes (e.g. to render a qualifier in the user interface
 	// if necessary). It can't be used to re-infer a hierarchy for the document
 	// symbols.
-	ContainerName string `json:"containerName,omitempty"`
+	ContainerName string  `json:"containerName,omitempty"`
+	Score         float64 `json:"score,omitempty"` // added for clangd compatibility
 }
 
 // @since 3.16.0
@@ -128,7 +129,6 @@ type CallHierarchyItem struct {
 	Name string `json:"name"`
 	// The kind of this item.
 	Kind SymbolKind `json:"kind"`
-
 	// Tags for this item.
 	Tags []SymbolTag `json:"tags,omitempty"`
 	// More detail for this item, e.g. the signature of a function.
@@ -142,7 +142,7 @@ type CallHierarchyItem struct {
 	SelectionRange Range `json:"selectionRange"`
 	// A data entry field that is preserved between a call hierarchy prepare and
 	// incoming calls or outgoing calls requests.
-	Data interface{} `json:"data,omitempty"`
+	Data any `json:"data,omitempty"`
 }
 
 // Call hierarchy options used during static registration.
@@ -256,7 +256,7 @@ type ClientCapabilities struct {
 	// @since 3.16.0
 	General *GeneralClientCapabilities `json:"general,omitempty"`
 	// Experimental client capabilities.
-	Experimental interface{} `json:"experimental,omitempty"`
+	Experimental any `json:"experimental,omitempty"`
 }
 
 // @since 3.18.0
@@ -765,7 +765,7 @@ type CodeLens struct {
 	Command *Command `json:"command,omitempty"`
 	// A data entry field that is preserved on a code lens item between
 	// a {@link CodeLensRequest} and a {@link CodeLensResolveRequest}
-	Data interface{} `json:"data,omitempty"`
+	Data any `json:"data,omitempty"`
 }
 
 // The client capabilities  of a {@link CodeLensRequest}.
@@ -1054,7 +1054,7 @@ type CompletionItem struct {
 	Command *Command `json:"command,omitempty"`
 	// A data entry field that is preserved on a completion item between a
 	// {@link CompletionRequest} and a {@link CompletionResolveRequest}.
-	Data interface{} `json:"data,omitempty"`
+	Data any `json:"data,omitempty"`
 }
 
 // In many cases the items of an actual completion result share the same
@@ -1092,7 +1092,7 @@ type CompletionItemDefaults struct {
 	// A default data value.
 	//
 	// @since 3.17.0
-	Data interface{} `json:"data,omitempty"`
+	Data any `json:"data,omitempty"`
 }
 
 // The kind of a completion entry.
@@ -1570,7 +1570,7 @@ type DidChangeConfigurationClientCapabilities struct {
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#didChangeConfigurationParams
 type DidChangeConfigurationParams struct {
 	// The actual changed settings
-	Settings interface{} `json:"settings"`
+	Settings any `json:"settings"`
 }
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#didChangeConfigurationRegistrationOptions
@@ -1906,7 +1906,7 @@ type DocumentLink struct {
 	Tooltip string `json:"tooltip,omitempty"`
 	// A data entry field that is preserved on a document link between a
 	// DocumentLinkRequest and a DocumentLinkResolveRequest.
-	Data interface{} `json:"data,omitempty"`
+	Data any `json:"data,omitempty"`
 }
 
 // The client capabilities of a {@link DocumentLinkRequest}.
@@ -2709,7 +2709,7 @@ type InlayHint struct {
 	PaddingRight bool `json:"paddingRight,omitempty"`
 	// A data entry field that is preserved on an inlay hint between
 	// a `textDocument/inlayHint` and a `inlayHint/resolve` request.
-	Data interface{} `json:"data,omitempty"`
+	Data any `json:"data,omitempty"`
 }
 
 // Inlay hint client capabilities.
@@ -3060,13 +3060,13 @@ type InsertTextFormat uint32
 //
 // @since 3.16.0
 type InsertTextMode uint32
-type LSPAny = interface{}
+type LSPAny = any
 
 // LSP arrays.
 // @since 3.17.0
 //
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#lSPArray
-type LSPArray = []interface{} // (alias)
+type LSPArray = []any // (alias)
 type LSPErrorCodes int32
 
 // LSP object definition.
@@ -3634,417 +3634,417 @@ type OptionalVersionedTextDocumentIdentifier struct {
 
 // created for Or [int32 string]
 type Or_CancelParams_id struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [ClientSemanticTokensRequestFullDelta bool]
 type Or_ClientSemanticTokensRequestOptions_full struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [Lit_ClientSemanticTokensRequestOptions_range_Item1 bool]
 type Or_ClientSemanticTokensRequestOptions_range struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [EditRangeWithInsertReplace Range]
 type Or_CompletionItemDefaults_editRange struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [MarkupContent string]
 type Or_CompletionItem_documentation struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [InsertReplaceEdit TextEdit]
 type Or_CompletionItem_textEdit struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [Location []Location]
 type Or_Declaration struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [Location []Location]
 type Or_Definition struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [int32 string]
 type Or_Diagnostic_code struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [[]string string]
 type Or_DidChangeConfigurationRegistrationOptions_section struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [RelatedFullDocumentDiagnosticReport RelatedUnchangedDocumentDiagnosticReport]
 type Or_DocumentDiagnosticReport struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport]
 type Or_DocumentDiagnosticReportPartialResult_relatedDocuments_Value struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [NotebookCellTextDocumentFilter TextDocumentFilter]
 type Or_DocumentFilter struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [Pattern RelativePattern]
 type Or_GlobPattern struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [MarkedString MarkupContent []MarkedString]
 type Or_Hover_contents struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [MarkupContent string]
 type Or_InlayHintLabelPart_tooltip struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [[]InlayHintLabelPart string]
 type Or_InlayHint_label struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [MarkupContent string]
 type Or_InlayHint_tooltip struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [StringValue string]
 type Or_InlineCompletionItem_insertText struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [InlineValueEvaluatableExpression InlineValueText InlineValueVariableLookup]
 type Or_InlineValue struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [LSPArray LSPObject bool float64 int32 string uint32]
 type Or_LSPAny struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [MarkedStringWithLanguage string]
 type Or_MarkedString struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [NotebookDocumentFilter string]
 type Or_NotebookCellTextDocumentFilter_notebook struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [NotebookDocumentFilterNotebookType NotebookDocumentFilterPattern NotebookDocumentFilterScheme]
 type Or_NotebookDocumentFilter struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [NotebookDocumentFilter string]
 type Or_NotebookDocumentFilterWithCells_notebook struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [NotebookDocumentFilter string]
 type Or_NotebookDocumentFilterWithNotebook_notebook struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [NotebookDocumentFilterWithCells NotebookDocumentFilterWithNotebook]
 type Or_NotebookDocumentSyncOptions_notebookSelector_Elem struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [MarkupContent string]
 type Or_ParameterInformation_documentation struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [Tuple_ParameterInformation_label_Item1 string]
 type Or_ParameterInformation_label struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [PrepareRenameDefaultBehavior PrepareRenamePlaceholder Range]
 type Or_PrepareRenameResult struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [int32 string]
 type Or_ProgressToken struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport]
 type Or_RelatedFullDocumentDiagnosticReport_relatedDocuments_Value struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport]
 type Or_RelatedUnchangedDocumentDiagnosticReport_relatedDocuments_Value struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [URI WorkspaceFolder]
 type Or_RelativePattern_baseUri struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [CodeAction Command]
 type Or_Result_textDocument_codeAction_Item0_Elem struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [CompletionList []CompletionItem]
 type Or_Result_textDocument_completion struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [Declaration []DeclarationLink]
 type Or_Result_textDocument_declaration struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [Definition []DefinitionLink]
 type Or_Result_textDocument_definition struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [[]DocumentSymbol []SymbolInformation]
 type Or_Result_textDocument_documentSymbol struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [Definition []DefinitionLink]
 type Or_Result_textDocument_implementation struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [InlineCompletionList []InlineCompletionItem]
 type Or_Result_textDocument_inlineCompletion struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [SemanticTokens SemanticTokensDelta]
 type Or_Result_textDocument_semanticTokens_full_delta struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [Definition []DefinitionLink]
 type Or_Result_textDocument_typeDefinition struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [[]SymbolInformation []WorkspaceSymbol]
 type Or_Result_workspace_symbol struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [SemanticTokensFullDelta bool]
 type Or_SemanticTokensOptions_full struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [Lit_SemanticTokensOptions_range_Item1 bool]
 type Or_SemanticTokensOptions_range struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [CallHierarchyOptions CallHierarchyRegistrationOptions bool]
 type Or_ServerCapabilities_callHierarchyProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [CodeActionOptions bool]
 type Or_ServerCapabilities_codeActionProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [DocumentColorOptions DocumentColorRegistrationOptions bool]
 type Or_ServerCapabilities_colorProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [DeclarationOptions DeclarationRegistrationOptions bool]
 type Or_ServerCapabilities_declarationProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [DefinitionOptions bool]
 type Or_ServerCapabilities_definitionProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [DiagnosticOptions DiagnosticRegistrationOptions]
 type Or_ServerCapabilities_diagnosticProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [DocumentFormattingOptions bool]
 type Or_ServerCapabilities_documentFormattingProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [DocumentHighlightOptions bool]
 type Or_ServerCapabilities_documentHighlightProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [DocumentRangeFormattingOptions bool]
 type Or_ServerCapabilities_documentRangeFormattingProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [DocumentSymbolOptions bool]
 type Or_ServerCapabilities_documentSymbolProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [FoldingRangeOptions FoldingRangeRegistrationOptions bool]
 type Or_ServerCapabilities_foldingRangeProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [HoverOptions bool]
 type Or_ServerCapabilities_hoverProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [ImplementationOptions ImplementationRegistrationOptions bool]
 type Or_ServerCapabilities_implementationProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [InlayHintOptions InlayHintRegistrationOptions bool]
 type Or_ServerCapabilities_inlayHintProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [InlineCompletionOptions bool]
 type Or_ServerCapabilities_inlineCompletionProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [InlineValueOptions InlineValueRegistrationOptions bool]
 type Or_ServerCapabilities_inlineValueProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [LinkedEditingRangeOptions LinkedEditingRangeRegistrationOptions bool]
 type Or_ServerCapabilities_linkedEditingRangeProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [MonikerOptions MonikerRegistrationOptions bool]
 type Or_ServerCapabilities_monikerProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [NotebookDocumentSyncOptions NotebookDocumentSyncRegistrationOptions]
 type Or_ServerCapabilities_notebookDocumentSync struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [ReferenceOptions bool]
 type Or_ServerCapabilities_referencesProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [RenameOptions bool]
 type Or_ServerCapabilities_renameProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [SelectionRangeOptions SelectionRangeRegistrationOptions bool]
 type Or_ServerCapabilities_selectionRangeProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [SemanticTokensOptions SemanticTokensRegistrationOptions]
 type Or_ServerCapabilities_semanticTokensProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [TextDocumentSyncKind TextDocumentSyncOptions]
 type Or_ServerCapabilities_textDocumentSync struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [TypeDefinitionOptions TypeDefinitionRegistrationOptions bool]
 type Or_ServerCapabilities_typeDefinitionProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [TypeHierarchyOptions TypeHierarchyRegistrationOptions bool]
 type Or_ServerCapabilities_typeHierarchyProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [WorkspaceSymbolOptions bool]
 type Or_ServerCapabilities_workspaceSymbolProvider struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [MarkupContent string]
 type Or_SignatureInformation_documentation struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [TextDocumentContentChangePartial TextDocumentContentChangeWholeDocument]
 type Or_TextDocumentContentChangeEvent struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [AnnotatedTextEdit SnippetTextEdit TextEdit]
 type Or_TextDocumentEdit_edits_Elem struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [TextDocumentFilterLanguage TextDocumentFilterPattern TextDocumentFilterScheme]
 type Or_TextDocumentFilter struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [SaveOptions bool]
 type Or_TextDocumentSyncOptions_save struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [WorkspaceFullDocumentDiagnosticReport WorkspaceUnchangedDocumentDiagnosticReport]
 type Or_WorkspaceDocumentDiagnosticReport struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [CreateFile DeleteFile RenameFile TextDocumentEdit]
 type Or_WorkspaceEdit_documentChanges_Elem struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [bool string]
 type Or_WorkspaceFoldersServerCapabilities_changeNotifications struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [TextDocumentContentOptions TextDocumentContentRegistrationOptions]
 type Or_WorkspaceOptions_textDocumentContent struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // created for Or [Location LocationUriOnly]
 type Or_WorkspaceSymbol_location struct {
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // The parameters of a configuration request.
@@ -4209,7 +4209,7 @@ type ProgressParams struct {
 	// The progress token provided by the client or server.
 	Token ProgressToken `json:"token"`
 	// The progress data.
-	Value interface{} `json:"value"`
+	Value any `json:"value"`
 }
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#progressToken
@@ -4314,7 +4314,7 @@ type Registration struct {
 	// The method / capability to register for.
 	Method string `json:"method"`
 	// Options necessary for the registration.
-	RegisterOptions interface{} `json:"registerOptions,omitempty"`
+	RegisterOptions any `json:"registerOptions,omitempty"`
 }
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#registrationParams
@@ -4871,7 +4871,7 @@ type ServerCapabilities struct {
 	// Workspace specific server capabilities.
 	Workspace *WorkspaceOptions `json:"workspace,omitempty"`
 	// Experimental server capabilities.
-	Experimental interface{} `json:"experimental,omitempty"`
+	Experimental any `json:"experimental,omitempty"`
 }
 
 // @since 3.18.0
@@ -5683,7 +5683,7 @@ type TypeHierarchyItem struct {
 	// supertypes or subtypes requests. It could also be used to identify the
 	// type hierarchy in the server, helping improve the performance on
 	// resolving supertypes and subtypes.
-	Data interface{} `json:"data,omitempty"`
+	Data any `json:"data,omitempty"`
 }
 
 // Type hierarchy options used during static registration.
@@ -6199,7 +6199,7 @@ type WorkspaceSymbol struct {
 	Location Or_WorkspaceSymbol_location `json:"location"`
 	// A data entry field that is preserved on a workspace symbol between a
 	// workspace symbol request and a workspace symbol resolve request.
-	Data interface{} `json:"data,omitempty"`
+	Data any `json:"data,omitempty"`
 	BaseSymbolInformation
 }
 
@@ -6311,7 +6311,7 @@ type XInitializeParams struct {
 	// The capabilities provided by the client (editor or tool)
 	Capabilities ClientCapabilities `json:"capabilities"`
 	// User provided initialization options.
-	InitializationOptions interface{} `json:"initializationOptions,omitempty"`
+	InitializationOptions any `json:"initializationOptions,omitempty"`
 	// The initial trace setting. If omitted trace is disabled ('off').
 	Trace *TraceValue `json:"trace,omitempty"`
 	WorkDoneProgressParams
@@ -6354,7 +6354,7 @@ type _InitializeParams struct {
 	// The capabilities provided by the client (editor or tool)
 	Capabilities ClientCapabilities `json:"capabilities"`
 	// User provided initialization options.
-	InitializationOptions interface{} `json:"initializationOptions,omitempty"`
+	InitializationOptions any `json:"initializationOptions,omitempty"`
 	// The initial trace setting. If omitted trace is disabled ('off').
 	Trace *TraceValue `json:"trace,omitempty"`
 	WorkDoneProgressParams

--- a/internal/tools/definition.go
+++ b/internal/tools/definition.go
@@ -46,7 +46,7 @@ func ReadDefinition(ctx context.Context, client *lsp.Client, symbolName string) 
 			} else {
 				// For unqualified names like "Method"
 				if v.Kind == protocol.Method {
-					// For methods, only match if the method name matches exactly Type.symbolName or symbolName
+					// For methods, only match if the method name matches exactly Type.symbolName or Type::symbolName or symbolName
 					if !strings.HasSuffix(symbol.GetName(), "::"+symbolName) && !strings.HasSuffix(symbol.GetName(), "."+symbolName) && symbol.GetName() != symbolName {
 						continue
 					}
@@ -63,6 +63,12 @@ func ReadDefinition(ctx context.Context, client *lsp.Client, symbolName string) 
 
 		toolsLogger.Debug("Found symbol: %s", symbol.GetName())
 		loc := symbol.GetLocation()
+
+		err := client.OpenFile(ctx, loc.URI.Path())
+		if err != nil {
+			toolsLogger.Error("Error opening file: %v", err)
+			continue
+		}
 
 		banner := "---\n\n"
 		definition, loc, err := GetFullDefinition(ctx, client, loc)

--- a/internal/tools/lsp-utilities.go
+++ b/internal/tools/lsp-utilities.go
@@ -56,12 +56,7 @@ func GetFullDefinition(ctx context.Context, client *lsp.Client, startLocation pr
 		return false
 	}
 
-	searchSymbols(symbols)
-
-	if !found {
-		// Fall back to the original location if we can't find a better range
-		symbolRange = startLocation.Range
-	}
+	found = searchSymbols(symbols)
 
 	if found {
 		// Convert URI to filesystem path
@@ -90,7 +85,7 @@ func GetFullDefinition(ctx context.Context, client *lsp.Client, startLocation pr
 		line := lines[symbolRange.End.Line]
 		trimmedLine := strings.TrimSpace(line)
 
-		// In some cases, constant definitions do not include the full body and instead
+		// In some cases (python), constant definitions do not include the full body and instead
 		// end with an opening bracket. In this case, parse the file until the closing bracket
 		if len(trimmedLine) > 0 {
 			lastChar := trimmedLine[len(trimmedLine)-1]

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ fmt:
 
 # Generate LSP types and methods
 generate:
-  go generate ./...
+  go run ./cmd/generate
 
 # Run code audit checks
 check:


### PR DESCRIPTION
- **Allow custom struct fields for LSP types**
- **Add Score to BaseSymbolInformation**
- **Open file in definition tool**
- **Misc comments and change `interface{}` to `any` in generate command**

For https://github.com/isaacphi/mcp-language-server/issues/27