### PR TITLE
Add a hack to remove 'struct ' prefix from symbols

### DIFF
--- a/internal/tools/definition.go
+++ b/internal/tools/definition.go
@@ -10,16 +10,9 @@ import (
 )
 
 func ReadDefinition(ctx context.Context, client *lsp.Client, symbolName string) (string, error) {
-	symbolResult, err := client.Symbol(ctx, protocol.WorkspaceSymbolParams{
-		Query: symbolName,
-	})
+	symbolName, results, err := QuerySymbol(ctx, client, symbolName)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch symbol: %v", err)
-	}
-
-	results, err := symbolResult.Results()
-	if err != nil {
-		return "", fmt.Errorf("failed to parse results: %v", err)
+		return "", err
 	}
 
 	var definitions []string

--- a/internal/tools/references.go
+++ b/internal/tools/references.go
@@ -22,16 +22,9 @@ func FindReferences(ctx context.Context, client *lsp.Client, symbolName string) 
 	}
 
 	// First get the symbol location like ReadDefinition does
-	symbolResult, err := client.Symbol(ctx, protocol.WorkspaceSymbolParams{
-		Query: symbolName,
-	})
+	symbolName, results, err := QuerySymbol(ctx, client, symbolName)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch symbol: %v", err)
-	}
-
-	results, err := symbolResult.Results()
-	if err != nil {
-		return "", fmt.Errorf("failed to parse results: %v", err)
+		return "", err
 	}
 
 	var allReferences []string


### PR DESCRIPTION
- clangd doesn't resolve these properly and this saves some context if we have to ask the LLM to do it?

... definitely a hack, open to other ideas too.

I couldn't get the clangd tests to run locally so I didn't bother adding a test case.