### PR TITLE
clangd: use smallest matching symbol as definition result

### DIFF
--- a/integrationtests/snapshots/clangd/definition/nsFunction.snap
+++ b/integrationtests/snapshots/clangd/definition/nsFunction.snap
@@ -1,0 +1,10 @@
+---
+
+Symbol: nsFunction2
+/TEST_OUTPUT/workspace/clangd/src/namespace.cpp
+Range: L11:C1 - L13:C2
+
+11|void nsFunction2() {
+12|    // empty   
+13|}
+

--- a/integrationtests/tests/clangd/definition/definition_test.go
+++ b/integrationtests/tests/clangd/definition/definition_test.go
@@ -66,6 +66,12 @@ func TestReadDefinition(t *testing.T) {
 			snapshotName: "method",
 		},
 		{
+			name:         "Namespace function",
+			symbolName:   "nsFunction2",
+			expectedText: "void nsFunction2()",
+			snapshotName: "nsFunction",
+		},
+		{
 			name:         "Struct",
 			symbolName:   "TestStruct",
 			expectedText: "struct TestStruct",

--- a/integrationtests/workspaces/clangd/Makefile
+++ b/integrationtests/workspaces/clangd/Makefile
@@ -29,7 +29,7 @@ TARGET_CLEAN_PROGRAM = clean_program # Assuming this is another program to be bu
 # Listing them explicitly for clarity in target dependencies.
 OBJ_MAIN = $(OBJDIR)/main.o
 # Add other specific object files your 'program' executable depends on
-OTHER_OBJS = $(OBJDIR)/helper.o $(OBJDIR)/types.o $(OBJDIR)/consumer.o $(OBJDIR)/another_consumer.o
+OTHER_OBJS = $(OBJDIR)/helper.o $(OBJDIR)/types.o $(OBJDIR)/consumer.o $(OBJDIR)/another_consumer.o $(OBJDIR)/namespace.o
 OBJ_FOR_CLEAN_PROGRAM = $(OBJDIR)/clean.o
 
 

--- a/integrationtests/workspaces/clangd/src/namespace.cpp
+++ b/integrationtests/workspaces/clangd/src/namespace.cpp
@@ -1,0 +1,15 @@
+//
+// A file with a namespace in it
+//
+
+namespace ns {
+
+void nsFunction1() {
+    // empty   
+}
+
+void nsFunction2() {
+    // empty   
+}
+
+}


### PR DESCRIPTION
- Current implementation takes the first symbol. That could be a namespace, and isn't usually what you want